### PR TITLE
docs: add lead-maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Publishing a test suite as a module lets multiple modules all ensure compatibili
 
 The API is presented with both Node.js and Go primitives, however, there is not actual limitations for it to be extended for any other language, pushing forward the cross compatibility and interop through diferent stacks.
 
+## Lead Maintainer
+
+[Vasco Santos](https://github.com/vasco-santos).
+
 ## Modules that implement the interface
 
 - [JavaScript libp2p-mdns](https://github.com/libp2p/js-libp2p-mdns)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "interface-discovery",
   "version": "0.0.2",
   "description": "A test suite and interface you can use to implement a discovery interface.",
+  "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "src/index.js",
   "scripts": {
     "lint": "aegir-lint",


### PR DESCRIPTION
In the context of https://github.com/ipfs/pm/issues/600, [js-libp2p#259](https://github.com/libp2p/js-libp2p/issues/259) and [js-libp2p/pull/265](https://github.com/libp2p/js-libp2p/pull/265).

Needs:

- [x] Update each package.json and README.md to have a leadMaintainer field.
- [x] Update [packages table](https://github.com/libp2p/js-libp2p/blob/3226632d83e8684e32b00eeb398b21158b94586d/README.md#packages) - [js-libp2p#265](https://github.com/libp2p/js-libp2p/pull/265)
- [ ] ~~Grant publish permission to the Maintainer~~ (doesn't exist yet on npm)